### PR TITLE
Fix comment syntax in Bounce Quest sketch

### DIFF
--- a/LILYGO T-DISPLAY AMOLED BOUNCE QUEST/source/BOUNCEQUEST/BOUNCEQUEST.ino
+++ b/LILYGO T-DISPLAY AMOLED BOUNCE QUEST/source/BOUNCEQUEST/BOUNCEQUEST.ino
@@ -11,7 +11,7 @@ const int initialPaddleWidth = 180;
 const int paddleHeight = 5; 
 int paddleX, paddleWidth; 
 const int paddleY = 530; 
-const int ballRadius = 3; 小球半径
+const int ballRadius = 3; // 小球半径
 int score = 0; //游戏内得分
 int highScore = 0; //最高得分
 bool gameActive = false; //标志


### PR DESCRIPTION
## Summary
- fix invalid inline comment on `ballRadius` constant in `BOUNCEQUEST.ino`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875e2e71c8083258de0cefbb6f5ea09